### PR TITLE
Update README to clone from HTTPS URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Run the following commands and enter your details when prompted:
 
 ```bash
 cd /Volumes/usb-volume-name-here
-git clone git@github.com:pivotal/usb-login-scripts.git
+git clone https://github.com/pivotal/usb-login-scripts.git
 ./usb-login-scripts/install.sh
 ```
 


### PR DESCRIPTION
Cloning from git@github.com URL requires having
logged into Github. People not logged into Github
accounts should still be able to clone the repository.